### PR TITLE
add getter for default tag name, make typeof attribute explicit

### DIFF
--- a/src/Midgard/CreatePHP/Entity/Controller.php
+++ b/src/Midgard/CreatePHP/Entity/Controller.php
@@ -107,6 +107,15 @@ class Controller extends Node implements EntityInterface
         return $this->_vocabularies;
     }
 
+    public function setRdfType($type)
+    {
+        $this->setAttribute('typeof', $type);
+    }
+    public function getRdfType()
+    {
+        return $this->getAttribute('typeof');
+    }
+
     /**
      * Object getter
      *

--- a/src/Midgard/CreatePHP/Node.php
+++ b/src/Midgard/CreatePHP/Node.php
@@ -180,6 +180,11 @@ abstract class Node implements NodeInterface
         $this->_tag_name = $tag;
     }
 
+    public function getTagName()
+    {
+        return $this->_tag_name;
+    }
+
     /**
      * Renders the element
      *

--- a/src/Midgard/CreatePHP/Type/CollectionDefinitionInterface.php
+++ b/src/Midgard/CreatePHP/Type/CollectionDefinitionInterface.php
@@ -65,4 +65,11 @@ interface CollectionDefinitionInterface extends ArrayAccess, Iterator
      * @param string $tag the html tag name without brackets
      */
     function setTagName($tag);
+
+    /**
+     * Get the current tag name of this type
+     *
+     * @return string the tag name
+     */
+    function getTagName();
 }

--- a/src/Midgard/CreatePHP/Type/PropertyDefinitionInterface.php
+++ b/src/Midgard/CreatePHP/Type/PropertyDefinitionInterface.php
@@ -36,4 +36,11 @@ interface PropertyDefinitionInterface
      * @param string $tag the html tag name without brackets
      */
     function setTagName($tag);
+
+    /**
+     * Get the current tag name of this type
+     *
+     * @return string the tag name
+     */
+    function getTagName();
 }

--- a/src/Midgard/CreatePHP/Type/TypeInterface.php
+++ b/src/Midgard/CreatePHP/Type/TypeInterface.php
@@ -47,6 +47,20 @@ interface TypeInterface
     function getVocabularies();
 
     /**
+     * Set the rdf type of this type, i.e. sioc:Post
+     *
+     * @param string $type the namespaced rdf type
+     */
+    function setRdfType($type);
+
+    /**
+     * Get the rdf type string of this type
+     *
+     * @return string
+     */
+    function getRdfType();
+
+    /**
      * Magic getter
      *
      * @param string $key
@@ -83,4 +97,11 @@ interface TypeInterface
      * @param string $tag the html tag name without brackets
      */
     function setTagName($tag);
+
+    /**
+     * Get the current tag name of this type
+     *
+     * @return string the tag name
+     */
+    function getTagName();
 }


### PR DESCRIPTION
having the tag name retrievable makes sense imho, and helps for testing.

the rdf type (typeof attribute in html) is very core, so i suggest having an explicit method for it, rather than the generic get/setAttribute
