### PR TITLE
add public to all interface methods to become PSR-2 compliant

### DIFF
--- a/src/Midgard/CreatePHP/Entity/Collection.php
+++ b/src/Midgard/CreatePHP/Entity/Collection.php
@@ -216,27 +216,27 @@ class Collection extends Node implements CollectionInterface
 
 
     /* ----- arrayaccess and iterator implementation methods ----- */
-    function rewind()
+    public function rewind()
     {
         $this->_position = 0;
     }
 
-    function current()
+    public function current()
     {
         return $this->_children[$this->_position];
     }
 
-    function key()
+    public function key()
     {
         return $this->_position;
     }
 
-    function next()
+    public function next()
     {
         ++$this->_position;
     }
 
-    function valid()
+    public function valid()
     {
         return isset($this->_children[$this->_position]);
     }

--- a/src/Midgard/CreatePHP/Entity/EntityInterface.php
+++ b/src/Midgard/CreatePHP/Entity/EntityInterface.php
@@ -24,7 +24,7 @@ interface EntityInterface extends TypeInterface
      *
      * @return mixed
      */
-    function getObject();
+    public function getObject();
 
     /**
      * Whether this node is editable. This is initialized from what
@@ -33,14 +33,14 @@ interface EntityInterface extends TypeInterface
      *
      * @return boolean
      */
-    function isEditable();
+    public function isEditable();
 
     /**
      * Overwrite whether this node is editable.
      *
      * @param boolean $value
      */
-    function setEditable($value);
+    public function setEditable($value);
 
     /**
      * Whether this entity is currently in process of being rendered.
@@ -50,5 +50,5 @@ interface EntityInterface extends TypeInterface
      *
      * @return boolean
      */
-    function isRendering();
+    public function isRendering();
 }

--- a/src/Midgard/CreatePHP/Entity/PropertyInterface.php
+++ b/src/Midgard/CreatePHP/Entity/PropertyInterface.php
@@ -28,26 +28,26 @@ interface PropertyInterface extends PropertyDefinitionInterface
      *
      * @return string
      */
-    function getValue();
+    public function getValue();
 
     /**
      * Change the value of this property
      *
      * @param string $value
      */
-    function setValue($value);
+    public function setValue($value);
 
     /**
      * Get the editor of this property
      *
      * @return string
      */
-    function getEditor();
+    public function getEditor();
 
     /**
      * Change the editor of this property
      *
      * @param string $editor
      */
-    function setEditor($editor);
+    public function setEditor($editor);
 }

--- a/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
@@ -53,7 +53,7 @@ abstract class AbstractRdfMapper implements RdfMapperInterface
      *
      * Just overwrite if you use a different concept.
      */
-    function prepareObject(TypeInterface $type, $parent = null)
+    public function prepareObject(TypeInterface $type, $parent = null)
     {
         if ($parent !== null) {
             throw new \Exception('Parent is not null, please extend this method to configure the parent');

--- a/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
@@ -42,7 +42,7 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper
      *
      * TODO: ensure that this has the right id resp. parent+name
      */
-    function store($object)
+    public function store($object)
     {
         $this->om->persist($object);
         $this->om->flush();

--- a/src/Midgard/CreatePHP/Metadata/RdfDriverArray.php
+++ b/src/Midgard/CreatePHP/Metadata/RdfDriverArray.php
@@ -76,7 +76,7 @@ class RdfDriverArray extends AbstractRdfDriver
      * @return \Midgard\CreatePHP\Type\TypeInterface the type if found
      * @throws \Midgard\CreatePHP\Metadata\TypeNotFoundException
      */
-    function loadTypeForClass($className, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory)
+    public function loadTypeForClass($className, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory)
     {
         if (! isset($this->definitions[$className])) {
             throw new TypeNotFoundException('No definition found for ' . $className);
@@ -176,7 +176,7 @@ class RdfDriverArray extends AbstractRdfDriver
      *
      * @return array The names of all classes known to this driver.
      */
-    function getAllClassNames()
+    public function getAllClassNames()
     {
         return array_keys($this->definitions);
     }

--- a/src/Midgard/CreatePHP/Metadata/RdfDriverInterface.php
+++ b/src/Midgard/CreatePHP/Metadata/RdfDriverInterface.php
@@ -30,12 +30,12 @@ interface RdfDriverInterface
      * @return \Midgard\CreatePHP\Type\TypeInterfacethe type if found
      * @throws \Midgard\CreatePHP\Metadata\TypeNotFoundException
      */
-    function loadTypeForClass($className, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory);
+    public function loadTypeForClass($className, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory);
 
     /**
      * Gets the names of all classes known to this driver.
      *
      * @return array The names of all classes known to this driver.
      */
-    function getAllClassNames();
+    public function getAllClassNames();
 }

--- a/src/Midgard/CreatePHP/Metadata/RdfDriverXml.php
+++ b/src/Midgard/CreatePHP/Metadata/RdfDriverXml.php
@@ -60,7 +60,7 @@ class RdfDriverXml extends AbstractRdfDriver
      * @return \Midgard\CreatePHP\NodeInterface the type if found
      * @throws \Midgard\CreatePHP\Metadata\TypeNotFoundException
      */
-    function loadTypeForClass($className, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory)
+    public function loadTypeForClass($className, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory)
     {
         $xml = $this->getXmlDefinition($className);
         if (null == $xml) {
@@ -156,7 +156,7 @@ class RdfDriverXml extends AbstractRdfDriver
      *
      * @return \SimpleXMLElement|null the definition or null if none found
      */
-    protected  function getXmlDefinition($className)
+    protected function getXmlDefinition($className)
     {
         $filename = $this->buildFileName($className);
         foreach ($this->directories as $dir) {
@@ -184,7 +184,7 @@ class RdfDriverXml extends AbstractRdfDriver
      *
      * @return array The names of all classes known to this driver.
      */
-    function getAllClassNames()
+    public function getAllClassNames()
     {
         //TODO loop through all provided paths and convert filenames back to class names
     }

--- a/src/Midgard/CreatePHP/NodeInterface.php
+++ b/src/Midgard/CreatePHP/NodeInterface.php
@@ -21,35 +21,35 @@ interface NodeInterface
      *
      * @param NodeInterface $parent The parent node
      */
-    function setParent(NodeInterface $parent);
+    public function setParent(NodeInterface $parent);
 
     /**
      * Parent node getter
      *
      * @return NodeInterface The parent object (if any)
      */
-    function getParent();
+    public function getParent();
 
     /**
      * Children getter
      *
      * @return array of NodeInterface (if any)
      */
-    function getChildren();
+    public function getChildren();
 
     /**
      * Set the tag name to use when rendering properties of this type
      *
      * @param string $tag the html tag name without brackets
      */
-    function setTagName($tag);
+    public function setTagName($tag);
 
     /**
      * Get the current tag name of this type
      *
      * @return string the tag name
      */
-    function getTagName();
+    public function getTagName();
 
     /**
      * Sets the template used for rendering. The template must have the placeholders
@@ -57,7 +57,7 @@ interface NodeInterface
      *
      * @param string $template
      */
-    function setTemplate($template);
+    public function setTemplate($template);
 
     /**
      * Adds or overwrites an html attribute
@@ -65,7 +65,7 @@ interface NodeInterface
      * @param string $key
      * @param string $value
      */
-    function setAttribute($key, $value);
+    public function setAttribute($key, $value);
 
     /**
      * Sets the attributes in the passed array, keeping
@@ -73,7 +73,7 @@ interface NodeInterface
      *
      * @param array $attributes key => value
      */
-    function setAttributes($attributes);
+    public function setAttributes($attributes);
 
     /**
      * Get a html attribute.
@@ -85,7 +85,7 @@ interface NodeInterface
      *
      * @return string the value for this attribute or null if no such attribute
      */
-    function getAttribute($key);
+    public function getAttribute($key);
 
     /**
      * Get all html attributes, including the system ones like typeof, rev, property
@@ -94,14 +94,14 @@ interface NodeInterface
      *
      * @return array of name => value
      */
-    function getAttributes();
+    public function getAttributes();
 
     /**
      * Remove an html attribute
      *
      * @param string $key
      */
-    function unsetAttribute($key);
+    public function unsetAttribute($key);
 
     /**
      * Renders everything including wrapper html tag and properties
@@ -122,14 +122,14 @@ interface NodeInterface
      *
      * @return string the rendered html
      */
-    function renderStart($tag_name = false);
+    public function renderStart($tag_name = false);
 
     /**
      * Render the content of this node, including its children if applicable
      *
      * @return string the rendered html
      */
-    function renderContent();
+    public function renderContent();
 
     /**
      * Render tail part for this node
@@ -144,7 +144,7 @@ interface NodeInterface
      *
      * @return string the rendered attributes
      */
-    function renderAttributes();
+    public function renderAttributes();
 
     /**
      * Has to return the same as self::render()

--- a/src/Midgard/CreatePHP/RdfMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfMapperInterface.php
@@ -30,7 +30,7 @@ interface RdfMapperInterface
      *
      * @return mixed the updated object
      */
-    function setPropertyValue($object, PropertyInterface $property, $value);
+    public function setPropertyValue($object, PropertyInterface $property, $value);
 
     /**
      * Get property from this object
@@ -40,7 +40,7 @@ interface RdfMapperInterface
      *
      * @return mixed
      */
-    function getPropertyValue($object, PropertyInterface $property);
+    public function getPropertyValue($object, PropertyInterface $property);
 
     /**
      * Tell if the object is editable
@@ -49,7 +49,7 @@ interface RdfMapperInterface
      *
      * @return boolean
      */
-    function isEditable($object);
+    public function isEditable($object);
 
     /**
      * Get object's children
@@ -59,7 +59,7 @@ interface RdfMapperInterface
      *
      * @return array of children objects
      */
-    function getChildren($object, CollectionInterface $collection);
+    public function getChildren($object, CollectionInterface $collection);
 
     /**
      * Ensure this classname is in its canonical form so it can be used for
@@ -72,7 +72,7 @@ interface RdfMapperInterface
      *
      * @return string the canonical name for this class
      */
-    function canonicalClassName($className);
+    public function canonicalClassName($className);
 
     /**
      * Instantiate a new object for the specified RDFa type
@@ -86,7 +86,7 @@ interface RdfMapperInterface
      *
      * @return mixed the object
      */
-    function prepareObject(TypeInterface $controller, $parent = null);
+    public function prepareObject(TypeInterface $controller, $parent = null);
 
     /**
      * Save object
@@ -95,7 +95,7 @@ interface RdfMapperInterface
      *
      * @return boolean whether storing was successful
      */
-    function store($object);
+    public function store($object);
 
     /**
      * Load object by json-ld subject (this is the RDFa about field)
@@ -104,7 +104,7 @@ interface RdfMapperInterface
      *
      * @return mixed The storage object or false if nothing is found
      */
-    function getBySubject($subject);
+    public function getBySubject($subject);
 
     /**
      * Create json-ld subject (RDFa about) for this object (could be simply the
@@ -117,5 +117,5 @@ interface RdfMapperInterface
      *
      * @return string
      */
-    function createSubject($object);
+    public function createSubject($object);
 }

--- a/src/Midgard/CreatePHP/Type/CollectionDefinitionInterface.php
+++ b/src/Midgard/CreatePHP/Type/CollectionDefinitionInterface.php
@@ -27,42 +27,42 @@ interface CollectionDefinitionInterface extends ArrayAccess, Iterator, RdfElemen
      *
      * @param string $typename the argument to be used with RdfTypeFactory::getType
      */
-    function setTypeName($typename);
+    public function setTypeName($typename);
 
     /**
      * Get the overriding RDFa type for the items of this collection
      *
      * @return TypeInterface
      */
-    function getType();
+    public function getType();
 
     /**
      * Set the reverse link of this collection (typically dcterms:partOf)
      *
      * @param string $rev
      */
-    function setRev($rev);
+    public function setRev($rev);
 
     /**
      * Get the reverse link of this collection (typically dcterms:partOf)
      *
      * @return string reverse link
      */
-    function getRev();
+    public function getRev();
 
     /**
      * Set the related link of this collection (typically dcterms:hasPart)
      *
      * @param string $rel
      */
-    function setRel($rel);
+    public function setRel($rel);
 
     /**
      * Get the related link of this collection (typically dcterms:hasPart)
      *
      * @return string the related name
      */
-    function getRel();
+    public function getRel();
 
     /**
      * Create a concrete collection from this definition with the children of the specified parent
@@ -71,27 +71,27 @@ interface CollectionDefinitionInterface extends ArrayAccess, Iterator, RdfElemen
      *
      * @return \Midgard\CreatePHP\Entity\CollectionInterface
      */
-    function createWithParent(EntityInterface $parent);
+    public function createWithParent(EntityInterface $parent);
 
     /**
      * Get the identifier value of this property (RDFa attribute)
      *
      * @return string
      */
-    function getIdentifier();
+    public function getIdentifier();
 
     /**
      * Containing type setter
      *
      * @param TypeInterface $parent The parent node
      */
-    function setParentType(TypeInterface $parent);
+    public function setParentType(TypeInterface $parent);
 
     /**
      * Containing type getter
      *
      * @return TypeInterface The parent type
      */
-    function getParentType();
+    public function getParentType();
 
 }

--- a/src/Midgard/CreatePHP/Type/PropertyDefinitionInterface.php
+++ b/src/Midgard/CreatePHP/Type/PropertyDefinitionInterface.php
@@ -21,41 +21,41 @@ interface PropertyDefinitionInterface extends RdfElementDefinitionInterface
      * @param string $value
      * @return \Midgard\CreatePHP\Entity\PropertyInterface
      */
-    function createWithValue($value);
+    public function createWithValue($value);
 
     /**
      * Get the identifier value of this property (RDFa attribute)
      *
      * @return string
      */
-    function getIdentifier();
+    public function getIdentifier();
 
     /**
      * Set the property rdfa name
      *
      * @param string $property
      */
-    function setProperty($property);
+    public function setProperty($property);
 
     /**
      * Get the property rdfa name
      *
      * @return string the rdf name of this property
      */
-    function getProperty();
+    public function getProperty();
 
     /**
      * Containing type setter
      *
      * @param TypeInterface $parent The parent node
      */
-    function setParentType(TypeInterface $parent);
+    public function setParentType(TypeInterface $parent);
 
     /**
      * Containing type getter
      *
      * @return TypeInterface The parent type
      */
-    function getParentType();
+    public function getParentType();
 
 }

--- a/src/Midgard/CreatePHP/Type/RdfElementDefinitionInterface.php
+++ b/src/Midgard/CreatePHP/Type/RdfElementDefinitionInterface.php
@@ -25,5 +25,5 @@ interface RdfElementDefinitionInterface
      *
      * @return array with client configuration
      */
-    function getConfig();
+    public function getConfig();
 }

--- a/src/Midgard/CreatePHP/Type/TypeInterface.php
+++ b/src/Midgard/CreatePHP/Type/TypeInterface.php
@@ -20,7 +20,7 @@ interface TypeInterface extends RdfElementDefinitionInterface
      *
      * @return \Midgard\CreatePHP\Entity\EntityInterface the entity of this type bound to the supplied object
      */
-    function createWithObject($object);
+    public function createWithObject($object);
 
     /**
      * Set a prefix to an uri to build the namespace mapping
@@ -28,28 +28,28 @@ interface TypeInterface extends RdfElementDefinitionInterface
      * @param $prefix
      * @param $uri
      */
-    function setVocabulary($prefix, $uri);
+    public function setVocabulary($prefix, $uri);
 
     /**
      * Get a map of all vocabularies
      *
      * @return array of prefix => uri
      */
-    function getVocabularies();
+    public function getVocabularies();
 
     /**
      * Set the rdf type of this type, i.e. sioc:Post
      *
      * @param string $type the namespaced rdf type
      */
-    function setRdfType($type);
+    public function setRdfType($type);
 
     /**
      * Get the rdf type string of this type
      *
      * @return string
      */
-    function getRdfType();
+    public function getRdfType();
 
     /**
      * Get the child node at this key
@@ -57,7 +57,7 @@ interface TypeInterface extends RdfElementDefinitionInterface
      * @param string $key
      * @return RdfElementDefinitionInterface|null
      */
-    function __get($key);
+    public function __get($key);
 
     /**
      * Set child node with this key
@@ -65,7 +65,7 @@ interface TypeInterface extends RdfElementDefinitionInterface
      * @param string $key
      * @param RdfElementDefinitionInterface $node
      */
-    function __set($key, RdfElementDefinitionInterface $node);
+    public function __set($key, RdfElementDefinitionInterface $node);
 
     /**
      * Check if child with this key exists
@@ -74,14 +74,14 @@ interface TypeInterface extends RdfElementDefinitionInterface
      *
      * @return boolean
      */
-    function __isset($key);
+    public function __isset($key);
 
     /**
      * Mapper getter
      *
      * @return \Midgard\CreatePHP\RdfMapperInterface
      */
-    function getMapper();
+    public function getMapper();
 
     /**
      * Get all children definitions of this type
@@ -89,5 +89,5 @@ interface TypeInterface extends RdfElementDefinitionInterface
      * @return array of PropertyDefinitionInterface|CollectionDefinitionInterface
      *      with the child definitions of this type
      */
-    function getChildDefinitions();
+    public function getChildDefinitions();
 }

--- a/src/Midgard/CreatePHP/WorkflowInterface.php
+++ b/src/Midgard/CreatePHP/WorkflowInterface.php
@@ -24,7 +24,7 @@ interface WorkflowInterface
      * @param mixed $object
      * @return array|null array to return for this workflow, or null if workflow is not allowed
      */
-    function getToolbarConfig($object);
+    public function getToolbarConfig($object);
 
     /**
      * Execute this workflow
@@ -36,5 +36,5 @@ interface WorkflowInterface
      *
      * @return array TODO what?
      */
-    function run($object);
+    public function run($object);
 }

--- a/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverArrayTest.php
+++ b/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverArrayTest.php
@@ -75,7 +75,7 @@ class RdfDriverArrayTest extends RdfDriverBase
      *
      * @return array The names of all classes known to this driver.
      */
-    function testGetAllClassNames()
+    public function testGetAllClassNames()
     {
         // TODO
     }

--- a/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverXmlTest.php
+++ b/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverXmlTest.php
@@ -41,7 +41,7 @@ class RdfDriverXmlTest extends RdfDriverBase
      *
      * @return array The names of all classes known to this driver.
      */
-    function testGetAllClassNames()
+    public function testGetAllClassNames()
     {
         // TODO
     }


### PR DESCRIPTION
PSR-2 says that interface methods need access qualifiers as well. all interface methods need to be public, nothing else makes sense.
