### PR TITLE
add section on collections to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ $manager = $loader->getManager($mapper);
 $entity = $manager->getEntity($object);
 ```
 
+
 ### Rendering HTML
 
 Using the default markup is as simple as this:
@@ -111,6 +112,7 @@ echo $entity->renderEnd();
 
 If you include the Create.js files into your page, all specified fields will become editable.
 
+
 ### Implementing the REST backend
 
 To actually save the data, you will have to provide an access point for the REST service, like so:
@@ -128,6 +130,7 @@ $jsonld = $service->run($type);
 send_as_json($jsonld);
 ?>
 ```
+
 
 ### Registering Workflows
 
@@ -149,9 +152,11 @@ send_as_json($toolbar_config);
 
 See the Create.js documentation for available configuration options in workflows
 
+
 # Reference
 
-## Type system: Types, Entities and Nodes
+
+## Type system: Types, Entities and Collections
 
 CreatePHP defines interfaces for the definition of RDF types, properties and
 collections. Then it defines extended interfaces for types bound to actual
@@ -166,6 +171,22 @@ settings if they implement NodeInterface) and then bind the type to a domain
 model object with createWithObject. createWithObject returns the Entity for
 this type bound to the value.
 
+
+### Collections
+
+A collection is a list of children entities of an entity. A collection may
+contain children of different types, but the metadata must specify the allowed
+child types. In the RDFa model, collections have a couple of attributes:
+
+* ``about`` the containing subject (can be inherited from containing HTML)
+* ``rel`` identifies the HTML element as a container of a collection. The value
+of the ``rel`` attribute is irrelevant for create.js and VIE.
+* ``rev`` if present, defines the attribute to be used on newly created entities
+in that collection that links back to the containing entity as specified in
+``about``. Createphp uses this to determine the parent entity when persisting a
+new entity.
+
+
 ## Metadata Factory
 
 To avoid building the type tree with verbose code, there is the
@@ -179,6 +200,7 @@ names. There are several drivers available:
   quick hack, but does not produce meaningful RDF.
 
 Look at the driver phpdoc for the exact syntax to use for configuration.
+
 
 ## Twig Extension
 


### PR DESCRIPTION
and another PR: udpate the doc a bit.

we should probably start to split this into more manageable chunks of documentation and identify what is missing. doc on xml mapping for example is not existing at all.
