### PR TITLE
Store entities instead of objects

### DIFF
--- a/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
@@ -10,6 +10,7 @@ namespace Midgard\CreatePHP\Mapper;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Midgard\CreatePHP\Entity\EntityInterface;
 
 /**
  * Base mapper for doctrine, removing the proxy class names in canonicalClassName
@@ -42,9 +43,9 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper
      *
      * TODO: ensure that this has the right id resp. parent+name
      */
-    public function store($object)
+    public function store(EntityInterface $entity)
     {
-        $this->om->persist($object);
+        $this->om->persist($entity);
         $this->om->flush();
         return true;
     }

--- a/src/Midgard/CreatePHP/RdfMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfMapperInterface.php
@@ -11,6 +11,7 @@ namespace Midgard\CreatePHP;
 use Midgard\CreatePHP\Entity\PropertyInterface;
 use Midgard\CreatePHP\Entity\CollectionInterface;
 use Midgard\CreatePHP\Type\TypeInterface;
+use Midgard\CreatePHP\Entity\EntityInterface;
 
 /**
  * Map from CreatePHP to your domain objects
@@ -93,13 +94,13 @@ interface RdfMapperInterface
     public function prepareObject(TypeInterface $controller, $parent = null);
 
     /**
-     * Save object
+     * Save an entity
      *
-     * @param mixed $object
+     * @param EntityInterface $entity
      *
      * @return boolean whether storing was successful
      */
-    public function store($object);
+    public function store(EntityInterface $entity);
 
     /**
      * Load object by json-ld subject (this is the RDFa about field)

--- a/src/Midgard/CreatePHP/RestService.php
+++ b/src/Midgard/CreatePHP/RestService.php
@@ -212,7 +212,7 @@ class RestService
             }
         }
 
-        if ($this->_mapper->store($object))
+        if ($this->_mapper->store($entity))
         {
             return $this->_convertToJsonld($new_values, $object, $entity);
         }

--- a/tests/Test/Midgard/CreatePHP/RestServiceTest.php
+++ b/tests/Test/Midgard/CreatePHP/RestServiceTest.php
@@ -3,6 +3,7 @@
 namespace Test\Midgard\CreatePHP;
 
 use Midgard\CreatePHP\RestService;
+use Midgard\CreatePHP\Entity\EntityInterface;
 
 class RestServiceTest extends \PHPUnit_Framework_TestCase
 {
@@ -47,7 +48,7 @@ class RestServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->expects($this->once())
             ->method('store')
-            ->with('testmodel')
+            ->with($this->entity)
             ->will($this->returnValue(true))
         ;
         $this->mapper->expects($this->once())

--- a/tests/__files/MockMapper.php
+++ b/tests/__files/MockMapper.php
@@ -5,6 +5,7 @@ use Midgard\CreatePHP\RdfMapperInterface;
 use Midgard\CreatePHP\Type\TypeInterface;
 use Midgard\CreatePHP\Entity\PropertyInterface;
 use Midgard\CreatePHP\Entity\CollectionInterface;
+use Midgard\CreatePHP\Entity\EntityInterface;
 
 /**
  * Mock RdfMapper implementation for unittests
@@ -49,7 +50,7 @@ class MockMapper implements RdfMapperInterface
 
     }
 
-    public function store($object)
+    public function store(EntityInterface $entity)
     {
 
     }


### PR DESCRIPTION
The RdfMapperInterface could store instances of EntityInterface instead of objects. This will add a lot of convenience into finalization of https://github.com/flack/createphp/pull/28.

Besides, it is really easy to get the object from the an entity, with the getObject() method. 

CC @dbu 
