### PR TITLE
add doctrine orm mapper and cleanup the base mapper to have no phpcr specific code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+Changelog
+=========
+
+* **2013-11-18**: Added mapper for Doctrine ORM. Removed
+  AbstractDoctrineMapper::createSubject as it contained invalid assumptions.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require-dev": {
-        "twig/twig": "~1.8"
+        "twig/twig": "~1.8",
+        "doctrine/common": "~2.3.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Midgard/CreatePHP/Mapper/DoctrineOrmMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/DoctrineOrmMapper.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @copyright CONTENT CONTROL GmbH, http://www.contentcontrol-berlin.de
+ * @author David Buchmann <david@liip.ch>
+ * @license Dual licensed under the MIT (MIT-LICENSE.txt) and LGPL (LGPL-LICENSE.txt) licenses.
+ * @package Midgard.CreatePHP
+ */
+
+namespace Midgard\CreatePHP\Mapper;
+
+use \RuntimeException;
+
+/**
+ * Mapper to handle Doctrine ORM.
+ */
+class DoctrineOrmMapper extends BaseDoctrineRdfMapper
+{
+    /**
+     * Escaping characters map.
+     *
+     * @var array
+     */
+    protected $escapeCharacters = array(
+        "\n" => '%0A',
+        '%' => '%25',
+        '"' => '%22',
+        '\'' => '%27',
+        '=' => '%3D',
+        '<' => '%3C',
+        '>' => '%3E',
+        '|' => '%7C',
+    );
+
+    /**
+     * {@inheritDoc}
+     *
+     * For the ORM, we need the class name to know in which table to look. The
+     * ORM can have multi field ids. Build the subject from all id's as per the
+     * metadata information as key=value pairs, concatenated with '|'.
+     */
+    public function createSubject($object)
+    {
+        $meta = $this->om->getClassMetaData(get_class($object));
+        $ids = $meta->getIdentifierValues($object);
+
+        $key = array();
+        foreach ($ids as $name => $id) {
+            $name = $this->escape($name);
+            $id = $this->escape($id);
+            $key[] = "$name=$id";
+        }
+
+        $idstring = implode('|', $key);
+
+        return $this->canonicalName(get_class($object)) . "|$idstring";
+    }
+
+     /**
+     * {@inheritDoc}
+     */
+    public function getBySubject($subject)
+    {
+        if (empty($subject)) {
+            throw new RuntimeException('Subject may not be empty');
+        }
+
+        $ids = explode('|', $subject);
+        if (count($ids) < 2) {
+            throw new RuntimeException("Invalid subject: $subject");
+        }
+        $class = ltrim($ids[0], '/'); // if we get the / from the url, this breaks the class loader in a funny way.
+        $repository = $this->om->getRepository($class);
+
+        array_shift($ids);
+        $identifiers = array();
+        foreach ($ids as $identifier) {
+            list($name, $id) = explode('=', $identifier);
+            $name = $this->unescape($name);
+            $id = $this->unescape($id);
+            $identifiers[$name] = $id;
+        }
+        $object = $repository->find($identifiers);
+
+        if (empty($object)) {
+            throw new RuntimeException("Not found: $subject");
+        }
+
+        return $object;
+    }
+
+    /**
+     * Escape a string to be used in an ID. Escapes all characters used in
+     * building the ID string and all potentially harmful when embedded in
+     * HTML.
+     *
+     * @param string $string Original string
+     *
+     * @return string The string with characters replaced
+     */
+    protected function escape($string)
+    {
+        return str_replace(array_keys($this->escapeCharacters), array_values($this->escapeCharacters), $string);
+    }
+
+    /**
+     * Restore the original string from the escaped one. Reverse operation of
+     * self::escape()
+     *
+     * @param string $string Escaped string
+     *
+     * @return string Original string
+     */
+    protected function unescape($string)
+    {
+        return str_replace(array_values($this->escapeCharacters), array_keys($this->escapeCharacters), $string);
+    }
+}

--- a/src/Midgard/CreatePHP/Mapper/DoctrinePhpcrOdmMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/DoctrinePhpcrOdmMapper.php
@@ -8,18 +8,15 @@
 
 namespace Midgard\CreatePHP\Mapper;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-
 use Midgard\CreatePHP\Type\TypeInterface;
 use Midgard\CreatePHP\Entity\EntityInterface;
+
+use PHPCR\ItemExistsException;
 
 use \RuntimeException;
 
 /**
  * Mapper to handle PHPCR-ODM.
- *
- * For orm, this will be more difficult as the subject will need to carry
- * the information of which entity it is about.
  */
 class DoctrinePhpcrOdmMapper extends BaseDoctrineRdfMapper
 {
@@ -71,7 +68,22 @@ class DoctrinePhpcrOdmMapper extends BaseDoctrineRdfMapper
             $meta->setFieldValue($entity->getObject(), $meta->nodename, $name);
         }
 
-        return parent::store($entity);
+        try {
+            return parent::store($entity);
+        } catch (ItemExistsException $iee) {
+            //an item with the same title already exists
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * With PHPCR-ODM we simply use the full repository path as id.
+     */
+    public function createSubject($object)
+    {
+        return $this->om->getUnitOfWork()->getDocumentId($object);
     }
 
     /**

--- a/tests/Test/Midgard/CreatePHP/Mapper/DoctrineOrmMapperTest.php
+++ b/tests/Test/Midgard/CreatePHP/Mapper/DoctrineOrmMapperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Test\Midgard\CreatePHP\Mapper;
+
+use Midgard\CreatePHP\Mapper\DoctrineOrmMapper;
+
+class DoctrineOrmMapperTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideIds()
+    {
+        return array(
+            array(
+                array('simplekey' => 'simplevalue'),
+            ),
+            array(
+                array(
+                    '%|=' => '%|=',
+                    '=%|' => '=%|',
+                    '=|%' => '=|%',
+                    '=' => '=',
+                    '|' => '|',
+                ),
+            )
+        );
+    }
+
+    /**
+     * @dataProvider provideIds
+     */
+    public function testSubject(array $ids)
+    {
+        $entity = new MockOrmEntity();
+
+        $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository
+            ->expects($this->once())
+            ->method('find')
+            ->with($ids)
+            ->will($this->returnValue($entity))
+        ;
+        $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $om
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with(get_class($entity))
+            ->will($this->returnValue($repository))
+        ;
+        $meta = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $meta
+            ->expects($this->once())
+            ->method('getIdentifierValues')
+            ->with($entity)
+            ->will($this->returnValue($ids))
+        ;
+        $om
+            ->expects($this->once())
+            ->method('getClassMetaData')
+            ->will($this->returnValue($meta))
+        ;
+
+        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry
+            ->expects($this->once())
+            ->method('getManager')
+            ->will($this->returnValue($om))
+        ;
+
+        $mapper = new DoctrineOrmMapper(array(), $registry);
+        $subject = $mapper->createSubject($entity);
+        $this->assertSame($entity, $mapper->getBySubject($subject));
+    }
+}
+
+class MockOrmEntity
+{
+}


### PR DESCRIPTION
the changes in the phpcr mapper should be no bc break so it should be fine to put into the 0.9 which master currently represents.

this PR does not cover to not expose class names publicly as this involves more refactoring on the library. i created a feature request for that: #57 . same holds about #58, it would be nice to be able to mix objects from various mappers but its out of scope for this PR.
