### PR TITLE
allow the object of the {% createphp %} tag to be any expression

### DIFF
--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpNode.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpNode.php
@@ -26,23 +26,29 @@ class CreatephpNode extends Twig_Node
      *
      *  * varname: The name of the rdfa entity to expose to the body node
      *
-     * @param Twig_NodeInterface $body       The body node
-     * @param string             $modelname  The name of the model class to make an rdfa entity
-     * @param string             $varname    The name for the rdfa entity to expose
-     * @param boolean            $autotag    Automatically render start and end part of the node?
-     * @param integer            $lineno     The line number
-     * @param string             $tag        The tag name
+     * @param Twig_NodeInterface $body     The body of the createphp token
+     * @param Twig_NodeInterface $object   The object to convert to rdf
+     * @param string|null        $varname  The name for the rdfa entity to expose or null if no explicit name
+     * @param boolean            $autotag  Automatically render start and end part of the node?
+     * @param integer            $lineno   The line number
+     * @param string             $tag      The tag name
      */
-    public function __construct(Twig_NodeInterface $body, $modelname, $varname, $autotag, $lineno = 0, $tag = null)
-    {
+    public function __construct(
+        Twig_NodeInterface $body,
+        Twig_NodeInterface $object,
+        $varname,
+        $autotag,
+        $lineno = 0,
+        $tag = null
+    ) {
         $nodes = array('body' => $body);
         if (empty($varname)) {
-            $varname = $modelname . '_rdf';
+            $varname = $this->findVariableName($object) . '_rdf';
         }
 
         $attributes = array(
             'varname' => $varname,
-            'modelname' => $modelname,
+            'object' => $object,
             'autotag' => $autotag
         );
 
@@ -60,7 +66,7 @@ class CreatephpNode extends Twig_Node
             ->raw('] = ')
         ;
 
-        $this->compileTypeLoad($compiler, $this->getAttribute('modelname'));
+        $this->compileTypeLoad($compiler, 'mymodel');
 
         $compiler
             ->raw(";\n")
@@ -107,9 +113,39 @@ class CreatephpNode extends Twig_Node
     {
         $compiler
             ->write('$this->env->getExtension(\'createphp\')->createEntity(')
-            ->raw('$context[')
-            ->repr($modelname)
-            ->raw("]);\n")
         ;
+        $compiler->subcompile($this->getAttribute('object'));
+        $compiler
+            ->raw(");\n")
+        ;
+    }
+
+    /**
+     * Get the name for the rdf variable by taking it from the last piece that
+     * is a name.
+     *
+     * For example container.method.content will make the name "content"
+     *
+     * @param Twig_NodeInterface $node
+     *
+     * @return string|null get the variable name
+     */
+    protected function findVariableName(Twig_NodeInterface $node)
+    {
+        $name = null;
+        if ($node instanceof \Twig_Node_Expression_Name) {
+            $name = $node->getAttribute('name');
+        } elseif ($node instanceof \Twig_Node_Expression_Constant) {
+            $name = $node->getAttribute('value');
+        }
+
+        foreach ($node as $child) {
+            $ret = $this->findVariableName($child);
+            if ($ret) {
+                $name = $ret;
+            }
+        }
+
+        return $name;
     }
 }

--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpTokenParser.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpTokenParser.php
@@ -39,13 +39,15 @@ class CreatephpTokenParser extends Twig_TokenParser
     {
         $stream = $this->parser->getStream();
 
-        // modelvariable
-        $modelname = $stream->expect(Twig_Token::NAME_TYPE)->getValue();
+        // the object might be an expression like container.field
+        $object = $this->parser->getExpressionParser()->parseExpression();
 
         $var = null;
         if ($stream->test(Twig_Token::NAME_TYPE, 'as')) {
             $stream->next();
-            $stream->expect(Twig_Token::OPERATOR_TYPE, '=');
+            if ($stream->test(Twig_Token::OPERATOR_TYPE, '=')) {
+                $stream->expect(Twig_Token::OPERATOR_TYPE, '=');
+            }
             $var = $stream->expect(Twig_Token::STRING_TYPE)->getValue();
         }
 
@@ -62,7 +64,7 @@ class CreatephpTokenParser extends Twig_TokenParser
         $body = $this->parser->subparse($test, true);
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
 
-        return new CreatephpNode($body, $modelname, $var, !$noautotag, $token->getLine(), $this->getTag());
+        return new CreatephpNode($body, $object, $var, !$noautotag, $token->getLine(), $this->getTag());
     }
 
     public function getTag()

--- a/tests/Test/Midgard/CreatePHP/Container.php
+++ b/tests/Test/Midgard/CreatePHP/Container.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Test\Midgard\CreatePHP;
+
+class Container
+{
+    private $content;
+
+    public function __construct($content) {
+        $this->content = $content;
+    }
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
+++ b/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
@@ -5,6 +5,7 @@ namespace Test\Midgard\CreatePHP\Extension\Twig;
 use Midgard\CreatePHP\Extension\Twig\CreatephpExtension;
 use Midgard\CreatePHP\Extension\Twig\CreatephpNode;
 
+use Test\Midgard\CreatePHP\Container;
 use Test\Midgard\CreatePHP\Model;
 use Test\Midgard\CreatePHP\Collection;
 use Midgard\CreatePHP\Metadata\RdfDriverXml;
@@ -72,7 +73,9 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
         return array(
             array('node.twig'),
             array('node_as.twig'),
-            array('functions.twig')
+            array('container.twig'),
+            array('container_as.twig'),
+            array('functions.twig'),
         );
     }
 
@@ -177,6 +180,8 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
     private function prepareBasicTest(){
         $model = new Model;
         $this->twig->addGlobal('mymodel', $model);
+        $container = new Container($model);
+        $this->twig->addGlobal('mycontainer', $container);
 
         $this->mapper->expects($this->any())
             ->method('getPropertyValue')

--- a/tests/Test/Midgard/CreatePHP/Extension/Twig/templates/container.twig
+++ b/tests/Test/Midgard/CreatePHP/Extension/Twig/templates/container.twig
@@ -1,0 +1,3 @@
+<test>
+{% createphp mycontainer.content %}{{ content_rdf|raw }}{% endcreatephp %}
+</test>

--- a/tests/Test/Midgard/CreatePHP/Extension/Twig/templates/container_as.twig
+++ b/tests/Test/Midgard/CreatePHP/Extension/Twig/templates/container_as.twig
@@ -1,0 +1,3 @@
+<test>
+{% createphp mycontainer.content as="rdf" %}{{ rdf|raw }}{% endcreatephp %}
+</test>


### PR DESCRIPTION
this is strictly backwards compatible. the only difference is that now you can do something like

```
{% createphp container.field.content %}
```

instead of having to use a direct variable present in the template, or a cludge like

```
{% set content = createphp container.field.content %}
{% content %}
```

At the same time, i make the `=` of `as="myname"`` optional to allow the more natural {% createphp content as "myname" %}
