### PR TITLE
Expose Workflows in RestSevice too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 Changelog
 =========
 
+* **2014-01-13**: Moved workflows from Manager to RestService. If you used
+  the Manager before, please update your code to use the RestService.
+  Before:
+  ```
+    $manager->registerWorkflow(...)
+  ```
+  After:
+  ```
+    $manager->getRestHandler()->registerWorkflow(...)
+  ```
+
 * **2013-11-18**: Added mapper for Doctrine ORM. Removed
   AbstractDoctrineMapper::createSubject as it contained invalid assumptions.

--- a/src/Midgard/CreatePHP/ArrayLoader.php
+++ b/src/Midgard/CreatePHP/ArrayLoader.php
@@ -37,7 +37,7 @@ class ArrayLoader
 
         if (!empty($this->_config['workflows'])) {
             foreach ($this->_config['workflows'] as $identifier => $classname) {
-                $manager->registerWorkflow($identifier, new $classname);
+                $manager->getRestHandler()->registerWorkflow($identifier, new $classname);
             }
         }
 

--- a/src/Midgard/CreatePHP/Manager.php
+++ b/src/Midgard/CreatePHP/Manager.php
@@ -29,18 +29,19 @@ class Manager
     protected $_metadata;
 
     /**
-     * Array of available workflows
-     *
-     * @var array of WorkflowInterface
-     */
-    protected $_workflows = array();
-
-    /**
      * The mapper implementation to use
      *
      * @var RdfMapperInterface
      */
     protected $_mapper;
+
+    /**
+     * The RestService
+     *
+     * @var RestService
+     */
+    protected $_restService;
+
 
     /**
      * The widget (JS constructor) to use
@@ -121,42 +122,9 @@ class Manager
 
     public function getRestHandler()
     {
-        $restservice = new RestService($this->_mapper);
-        foreach ($this->_workflows as $identifier => $workflow) {
-            $restservice->setWorkflow($identifier, $workflow);
+        if (null === $this->_restService) {
+            $this->_restService = new RestService($this->_mapper);
         }
-        return $restservice;
-    }
-
-    /**
-     * Register a workflow
-     *
-     * @param string $identifier
-     * @param WorkflowInterface $Workflow
-     */
-    public function registerWorkflow($identifier, WorkflowInterface $workflow)
-    {
-        $this->_workflows[$identifier] = $workflow;
-    }
-
-    /**
-     * Get all workflows available for this subject
-     *
-     * @param string $subject the RDFa identifier of the subject to get workflows for
-     *
-     * @return array of WorkflowInterface
-     */
-    public function getWorkflows($subject)
-    {
-        $response = array();
-        $object = $this->_mapper->getBySubject(trim($subject, '<>'));
-        foreach ($this->_workflows as $identifier => $workflow) {
-            /** @var $workflow WorkflowInterface */
-            $toolbar_config = $workflow->getToolbarConfig($object);
-            if (null !== $toolbar_config) {
-                $response[] = $toolbar_config;
-            }
-        }
-        return $response;
+        return $this->_restService;
     }
 }

--- a/src/Midgard/CreatePHP/RestService.php
+++ b/src/Midgard/CreatePHP/RestService.php
@@ -266,6 +266,17 @@ class RestService
     }
 
     /**
+     * Register a workflow
+     *
+     * @param string $identifier
+     * @param WorkflowInterface $workflow
+     */
+    public function registerWorkflow($identifier, WorkflowInterface $workflow)
+    {
+        $this->_workflows[$identifier] = $workflow;
+    }
+
+    /**
      * Get all workflows available for this subject
      *
      * @param string $subject the RDFa identifier of the subject to get workflows for

--- a/tests/ArrayLoaderTest.php
+++ b/tests/ArrayLoaderTest.php
@@ -106,7 +106,7 @@ class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new ArrayLoader($config);
         $manager = $loader->getManager($mapper);
 
-        $workflows = $manager->getWorkflows('test_id');
+        $workflows = $manager->getRestHandler()->getWorkflows('test_id');
 
         $expected = array
         (

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -42,28 +42,6 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($controller, $this->manager->getType('test'));
     }
 
-    public function test_get_registerWorkflow()
-    {
-        $workflow = new MockWorkflow;
-        $this->manager->registerWorkflow('mock', $workflow);
-
-        $expected = array
-        (
-            array
-            (
-                'name' => "mockbutton",
-                'label' => 'Mock Label',
-                'action' => array
-                (
-                    'type' => "backbone_destroy"
-                ),
-                'type' => "button"
-            )
-        );
-
-        $this->assertEquals($expected, $this->manager->getworkflows('test1'));
-    }
-
     public function test_getRestHandler()
     {
         $service = $this->manager->getRestHandler();

--- a/tests/Test/Midgard/CreatePHP/RestServiceWorkflowTest.php
+++ b/tests/Test/Midgard/CreatePHP/RestServiceWorkflowTest.php
@@ -7,14 +7,14 @@ use Midgard\CreatePHP\tests\MockWorkflow;
 
 class RestServiceWorkflowTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetworkflows()
+    public function test_get_registerWorkflow()
     {
         $workflow = new MockWorkflow;
         $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
 
-        $rest = new RestService($mapper);
+        $restHandler = new RestService($mapper);
 
-        $rest->setWorkflow('mock', $workflow);
+        $restHandler->registerWorkflow('mock', $workflow);
 
         $expected = array
         (
@@ -30,6 +30,6 @@ class RestServiceWorkflowTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->assertEquals($expected, $rest->getWorkflows('test1'));
+        $this->assertEquals($expected, $restHandler->getWorkflows('test1'));
     }
 }


### PR DESCRIPTION
This is code duplication from the Manager class, but SymfonyCMFs CreateBundle only uses the RestService, not the Manager and I need access to the workflows to make them available to create.js
