### PR TITLE
Add chain mapper implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.1
+-----
+* Added ChainRdfMapper and ChainedRdfMapperInterface to allow using more than one mapper in parallel.
+* BC break: If you implemented your own mapper, note that RdfMapperInterface::objectToName was added
+
+1.0
+-----
+
 * **2014-01-13**: Moved workflows from Manager to RestService. If you used
   the Manager before, please update your code to use the RestService.
   Before:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.9-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }

--- a/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
@@ -156,6 +156,18 @@ abstract class AbstractRdfMapper implements RdfMapperInterface
     }
 
     /**
+     * A dummy classname canonicalizer: returns the name unmodified.
+     *
+     * @param string $className
+     * @return string exactly the same as $className
+     * @deprecated Deprecated in 1.1 use objectToName instead.
+     */
+    public function canonicalName($className)
+    {
+        return $className;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * The default implementation uses get_class on objects
@@ -166,7 +178,7 @@ abstract class AbstractRdfMapper implements RdfMapperInterface
             throw new \RuntimeException("$object is not an object");
         }
 
-        return get_class($object);
+        return $this->canonicalName(get_class($object));
     }
 
     /**

--- a/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
@@ -58,15 +58,26 @@ abstract class AbstractRdfMapper implements RdfMapperInterface
         if ($parent !== null) {
             throw new \Exception('Parent is not null, please extend this method to configure the parent');
         }
-        list($prefix, $shortname) = explode(':', $type->getRdfType());
-        $ns = $type->getVocabularies();
-        $ns = $ns[$prefix];
-        $name = $ns.$shortname;
+        $name = $this->getTypeMapKey($type);
         if (isset($this->typeMap[$name])) {
             $class = $this->typeMap[$name];
             return new $class;
         }
         throw new \Exception('No information on ' . $name);
+    }
+
+    /**
+     * Get's the possible key used in the typemap for the type
+     *
+     * @param TypeInterface $type
+     * @return string
+     */
+    protected function getTypeMapKey(TypeInterface $type)
+    {
+        list($prefix, $shortname) = explode(':', $type->getRdfType());
+        $ns = $type->getVocabularies();
+        $ns = $ns[$prefix];
+        return $ns.$shortname;
     }
 
     /**
@@ -154,7 +165,7 @@ abstract class AbstractRdfMapper implements RdfMapperInterface
         if (! is_object($object)) {
             throw new \RuntimeException("$object is not an object");
         }
-        
+
         return get_class($object);
     }
 

--- a/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/AbstractRdfMapper.php
@@ -145,14 +145,17 @@ abstract class AbstractRdfMapper implements RdfMapperInterface
     }
 
     /**
-     * A dummy classname canonicalizer: returns the name unmodified.
+     * {@inheritDoc}
      *
-     * @param string $className
-     * @return string exactly the same as $className
+     * The default implementation uses get_class on objects
      */
-    public function canonicalName($className)
+    public function objectToName($object)
     {
-        return $className;
+        if (! is_object($object)) {
+            throw new \RuntimeException("$object is not an object");
+        }
+        
+        return get_class($object);
     }
 
     /**

--- a/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
@@ -10,9 +10,11 @@ namespace Midgard\CreatePHP\Mapper;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Midgard\CreatePHP\RdfChainableMapperInterface;
 use Midgard\CreatePHP\Entity\EntityInterface;
 use Midgard\CreatePHP\Entity\PropertyInterface;
+use Midgard\CreatePHP\Type\TypeInterface;
 
 /**
  * Base mapper for doctrine, removing the proxy class names in canonicalClassName
@@ -66,7 +68,7 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper implements  RdfCh
         if (in_array('Doctrine\\Common\\Persistence\\Proxy', $refl->getInterfaceNames())) {
             $className = \Doctrine\Common\Util\ClassUtils::getRealClass($className);
         }
-        
+
         return $className;
     }
 
@@ -108,8 +110,16 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper implements  RdfCh
     /**
      * {@inheritDoc}
      */
-    public function supportsCreate($object)
+    public function supportsCreate(TypeInterface $type)
     {
+        $name = $this->getTypeMapKey($type);
+        if (isset($this->typeMap[$name])) {
+            try {
+                $metadata = $this->om->getClassMetadata($this->typeMap[$name]);
+                return is_object($metadata);
+            } catch (MappingException $e) { }
+        }
+
         return false;
     }
 }

--- a/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
@@ -10,6 +10,7 @@ namespace Midgard\CreatePHP\Mapper;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Midgard\CreatePHP\RdfChainableMapperInterface;
 use Midgard\CreatePHP\Entity\EntityInterface;
 use Midgard\CreatePHP\Entity\PropertyInterface;
 
@@ -20,7 +21,7 @@ use Midgard\CreatePHP\Entity\PropertyInterface;
  *
  * @package Midgard.CreatePHP
  */
-abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper
+abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper implements  RdfChainableMapperInterface
 {
     /** @var ObjectManager */
     protected $om;
@@ -58,13 +59,14 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper
      *
      * use getRealClass if className names a doctrine proxy class.
      */
-    public function canonicalName($className)
+    public function objectToName($object)
     {
-        $refl = new \ReflectionClass($className);
+        $refl = new \ReflectionClass($object);
+        $className = $refl->getName();
         if (in_array('Doctrine\\Common\\Persistence\\Proxy', $refl->getInterfaceNames())) {
             $className = \Doctrine\Common\Util\ClassUtils::getRealClass($className);
         }
-
+        
         return $className;
     }
 
@@ -93,5 +95,21 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper
         }
 
         return parent::setPropertyValue($object, $property, $value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($object)
+    {
+        return $this->om->contains($object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsCreate($object)
+    {
+        return false;
     }
 }

--- a/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
@@ -126,8 +126,10 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper implements  RdfCh
         if (isset($this->typeMap[$name])) {
             try {
                 $metadata = $this->om->getClassMetadata($this->typeMap[$name]);
+
                 return is_object($metadata);
-            } catch (MappingException $e) { }
+            } catch (MappingException $e) {
+            }
         }
 
         return false;

--- a/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/BaseDoctrineRdfMapper.php
@@ -11,6 +11,7 @@ namespace Midgard\CreatePHP\Mapper;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use Doctrine\Common\Util\ClassUtils;
 use Midgard\CreatePHP\RdfChainableMapperInterface;
 use Midgard\CreatePHP\Entity\EntityInterface;
 use Midgard\CreatePHP\Entity\PropertyInterface;
@@ -61,15 +62,24 @@ abstract class BaseDoctrineRdfMapper extends AbstractRdfMapper implements  RdfCh
      *
      * use getRealClass if className names a doctrine proxy class.
      */
-    public function objectToName($object)
+    public function canonicalName($className)
     {
-        $refl = new \ReflectionClass($object);
-        $className = $refl->getName();
+        $refl = new \ReflectionClass($className);
         if (in_array('Doctrine\\Common\\Persistence\\Proxy', $refl->getInterfaceNames())) {
             $className = \Doctrine\Common\Util\ClassUtils::getRealClass($className);
         }
 
         return $className;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * use getRealClass if className names a doctrine proxy class.
+     */
+    public function objectToName($object)
+    {
+        return $this->canonicalName(ClassUtils::getClass($object));
     }
 
     /**

--- a/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
@@ -112,7 +112,17 @@ class ChainRdfMapper implements RdfMapperInterface
      */
     public function prepareObject(TypeInterface $controller, $parent = null)
     {
-        throw new RuntimeException("Not implemented yet.");
+        foreach ($this->mappers as $mapper)
+        {
+            if ($mapper->supportsCreate($controller)) {
+                $object = $mapper->prepareObject($controller, $parent);
+                $this->createdObjects[spl_object_hash($object)] = $mapper;
+
+                return $object;
+            }
+        }
+
+        throw new RuntimeException("No mapper can create an object for type.");
     }
 
     /**

--- a/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
@@ -102,6 +102,14 @@ class ChainRdfMapper implements RdfMapperInterface
     /**
      * {@inheritdoc}
      */
+    public function canonicalName($className)
+    {
+        return $className;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function objectToName($object)
     {
         return $this->getMapperForObject($object)->objectToName($object);

--- a/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Midgard\CreatePHP\Mapper;
+
+
+use Midgard\CreatePHP\RdfChainableMapperInterface;
+use Midgard\CreatePHP\RdfMapperInterface;
+use Midgard\CreatePHP\Entity\PropertyInterface;
+use Midgard\CreatePHP\Entity\CollectionInterface;
+use Midgard\CreatePHP\Type\TypeInterface;
+use Midgard\CreatePHP\Entity\EntityInterface;
+
+use \RuntimeException;
+
+/**
+ * Looks at all registered mappers to find one that can handle objects.
+ *
+ * @package Midgard.CreatePHP
+ */
+class ChainRdfMapper implements RdfMapperInterface
+{
+    /**
+     * All the registered mappers
+     *
+     * @var RdfMapperInterface[]
+     */
+    private $mappers = array();
+
+    /**
+     * Mappers index by the spl_object_hash of objects created by CreatePHP
+     *
+     * @var RdfMapperInterface[]
+     */
+    private $createdObjects = array();
+
+    /**
+     * Register a mapper with a key. The key will be prefixed to all subjects.
+     *
+     * @param RdfChainableMapperInterface $mapper
+     * @param string $mapperKey
+     */
+    public function registerMapper(RdfChainableMapperInterface $mapper, $mapperKey)
+    {
+        $this->mappers[$mapperKey] = $mapper;
+    }
+
+    /**
+     * Get the mapper than can handle object.
+     *
+     * @param mixed $object
+     * @return RdfChainableMapperInterface
+     * @throws RuntimeException when no mapper can handle the object
+     */
+    protected function getMapperForObject($object)
+    {
+        foreach ($this->mappers as $mapper)
+        {
+            if ($mapper->supports($object)) {
+                return $mapper;
+            }
+        }
+
+        $hash = spl_object_hash($object);
+        if (isset($this->createdObjects[$hash])) {
+            return $this->createdObjects[$hash];
+        }
+
+        throw new RuntimeException("No mapper can create a subject for object.");
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function setPropertyValue($object, PropertyInterface $property, $value)
+    {
+        return $this->getMapperForObject($object)->setPropertyValue($object, $property, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPropertyValue($object, PropertyInterface $property)
+    {
+        return $this->getMapperForObject($object)->getPropertyValue($object, $property);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEditable($object)
+    {
+        return $this->getMapperForObject($object)->isEditable($object);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChildren($object, CollectionInterface $collection)
+    {
+        return $this->getMapperForObject($object)->getChildren($object, $collection);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectToName($object)
+    {
+        return $this->getMapperForObject($object)->objectToName($object);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepareObject(TypeInterface $controller, $parent = null)
+    {
+        throw new RuntimeException("Not implemented yet.");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store(EntityInterface $entity)
+    {
+        return $this->getMapperForObject($entity->getObject())->store($entity);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBySubject($subject)
+    {
+        list($mapperKey, $mapperSubject) = explode('|', $subject, 2);
+
+        if (!isset($this->mappers[$mapperKey]))
+        {
+            throw new RuntimeException("Invalid subject: $subject");
+        }
+
+        $object = $this->mappers[$mapperKey]->getBySubject($mapperSubject);
+
+        return $object;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createSubject($object)
+    {
+        foreach ($this->mappers as $mapperKey => $mapper)
+        {
+            if ($mapper->supports($object)) {
+                return $mapperKey . '|' . $mapper->createSubject($object);
+            }
+        }
+
+        throw new RuntimeException("No mapper can create a subject for object.");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function orderChildren(EntityInterface $entity, CollectionInterface $node, $expectedOrder)
+    {
+        return $this->getMapperForObject($entity->getObject())->orderChildren($entity, $node, $expectedOrder);
+    }
+}

--- a/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/ChainRdfMapper.php
@@ -2,15 +2,13 @@
 
 namespace Midgard\CreatePHP\Mapper;
 
-
 use Midgard\CreatePHP\RdfChainableMapperInterface;
 use Midgard\CreatePHP\RdfMapperInterface;
 use Midgard\CreatePHP\Entity\PropertyInterface;
 use Midgard\CreatePHP\Entity\CollectionInterface;
 use Midgard\CreatePHP\Type\TypeInterface;
 use Midgard\CreatePHP\Entity\EntityInterface;
-
-use \RuntimeException;
+use RuntimeException;
 
 /**
  * Looks at all registered mappers to find one that can handle objects.
@@ -37,7 +35,7 @@ class ChainRdfMapper implements RdfMapperInterface
      * Register a mapper with a key. The key will be prefixed to all subjects.
      *
      * @param RdfChainableMapperInterface $mapper
-     * @param string $mapperKey
+     * @param string                      $mapperKey
      */
     public function registerMapper(RdfChainableMapperInterface $mapper, $mapperKey)
     {
@@ -47,14 +45,13 @@ class ChainRdfMapper implements RdfMapperInterface
     /**
      * Get the mapper than can handle object.
      *
-     * @param mixed $object
+     * @param  mixed                       $object
      * @return RdfChainableMapperInterface
-     * @throws RuntimeException when no mapper can handle the object
+     * @throws RuntimeException            when no mapper can handle the object
      */
     protected function getMapperForObject($object)
     {
-        foreach ($this->mappers as $mapper)
-        {
+        foreach ($this->mappers as $mapper) {
             if ($mapper->supports($object)) {
                 return $mapper;
             }
@@ -120,8 +117,7 @@ class ChainRdfMapper implements RdfMapperInterface
      */
     public function prepareObject(TypeInterface $controller, $parent = null)
     {
-        foreach ($this->mappers as $mapper)
-        {
+        foreach ($this->mappers as $mapper) {
             if ($mapper->supportsCreate($controller)) {
                 $object = $mapper->prepareObject($controller, $parent);
                 $this->createdObjects[spl_object_hash($object)] = $mapper;
@@ -130,7 +126,7 @@ class ChainRdfMapper implements RdfMapperInterface
             }
         }
 
-        throw new RuntimeException("No mapper can create an object for type.");
+        throw new RuntimeException(sprintf('None of the registered mappers can create an object of type %s', $controller->getRdfType()));
     }
 
     /**
@@ -148,8 +144,7 @@ class ChainRdfMapper implements RdfMapperInterface
     {
         list($mapperKey, $mapperSubject) = explode('|', $subject, 2);
 
-        if (!isset($this->mappers[$mapperKey]))
-        {
+        if (!isset($this->mappers[$mapperKey])) {
             throw new RuntimeException("Invalid subject: $subject");
         }
 
@@ -163,14 +158,13 @@ class ChainRdfMapper implements RdfMapperInterface
      */
     public function createSubject($object)
     {
-        foreach ($this->mappers as $mapperKey => $mapper)
-        {
+        foreach ($this->mappers as $mapperKey => $mapper) {
             if ($mapper->supports($object)) {
-                return $mapperKey . '|' . $mapper->createSubject($object);
+                return $mapperKey.'|'.$mapper->createSubject($object);
             }
         }
 
-        throw new RuntimeException("No mapper can create a subject for object.");
+        throw new RuntimeException(sprintf('None of the registered mappers can create the subject for object of class %s', get_class($object)));
     }
 
     /**

--- a/src/Midgard/CreatePHP/Mapper/DoctrineOrmMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/DoctrineOrmMapper.php
@@ -55,7 +55,7 @@ class DoctrineOrmMapper extends BaseDoctrineRdfMapper
 
         $idstring = implode('|', $key);
 
-        return str_replace('\\', '-', $this->canonicalName(get_class($object))) . "|$idstring";
+        return str_replace('\\', '-', $this->objectToName($object)) . "|$idstring";
     }
 
      /**

--- a/src/Midgard/CreatePHP/Mapper/DoctrineOrmMapper.php
+++ b/src/Midgard/CreatePHP/Mapper/DoctrineOrmMapper.php
@@ -55,7 +55,7 @@ class DoctrineOrmMapper extends BaseDoctrineRdfMapper
 
         $idstring = implode('|', $key);
 
-        return str_replace('\\', '-', $this->objectToName($object)) . "|$idstring";
+        return str_replace('\\', '-', $this->objectToName($object))."|$idstring";
     }
 
      /**

--- a/src/Midgard/CreatePHP/Metadata/AbstractRdfDriver.php
+++ b/src/Midgard/CreatePHP/Metadata/AbstractRdfDriver.php
@@ -72,19 +72,6 @@ abstract class AbstractRdfDriver implements RdfDriverInterface
     protected abstract function getAttributes($element);
 
     /**
-     * {@inheritDoc}
-     *
-     * The default implementation uses get_class on objects
-     */
-    public function objectToName($object, RdfMapperInterface $mapper)
-    {
-        if (! is_object($object)) {
-            throw new \RuntimeException("$object is not an object");
-        }
-        return $mapper->canonicalName(get_class($object));
-    }
-
-    /**
      * Create a type instance.
      *
      * @param RdfMapperInterface $mapper

--- a/src/Midgard/CreatePHP/Metadata/AbstractRdfDriver.php
+++ b/src/Midgard/CreatePHP/Metadata/AbstractRdfDriver.php
@@ -72,6 +72,16 @@ abstract class AbstractRdfDriver implements RdfDriverInterface
     protected abstract function getAttributes($element);
 
     /**
+     * {@inheritDoc}
+     *
+     * @deprecated Deprecated in 1.1 call on the mapper object instead.
+     */
+    public function objectToName($object, RdfMapperInterface $mapper)
+    {
+        return $mapper->objectToName($object);
+    }
+
+    /**
      * Create a type instance.
      *
      * @param RdfMapperInterface $mapper

--- a/src/Midgard/CreatePHP/Metadata/RdfDriverInterface.php
+++ b/src/Midgard/CreatePHP/Metadata/RdfDriverInterface.php
@@ -34,6 +34,17 @@ interface RdfDriverInterface
     public function loadType($name, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory);
 
     /**
+     * Get the name of an object
+     *
+     * @param object $object
+     *
+     * @return string the canonical name of this object
+     *
+     * @deprecated Deprecated in 1.1 call on the mapper object instead.
+     */
+    public function objectToName($object, RdfMapperInterface $mapper);
+
+    /**
      * Gets a map of rdf types to names with all types known to this driver.
      *
      * @return array of RDF type => name of all types known to this driver.

--- a/src/Midgard/CreatePHP/Metadata/RdfDriverInterface.php
+++ b/src/Midgard/CreatePHP/Metadata/RdfDriverInterface.php
@@ -34,15 +34,6 @@ interface RdfDriverInterface
     public function loadType($name, RdfMapperInterface $mapper, RdfTypeFactory $typeFactory);
 
     /**
-     * Get the name of an object
-     *
-     * @param object $object
-     *
-     * @return string the canonical name of this object
-     */
-    public function objectToName($object, RdfMapperInterface $mapper);
-
-    /**
      * Gets a map of rdf types to names with all types known to this driver.
      *
      * @return array of RDF type => name of all types known to this driver.

--- a/src/Midgard/CreatePHP/Metadata/RdfTypeFactory.php
+++ b/src/Midgard/CreatePHP/Metadata/RdfTypeFactory.php
@@ -44,7 +44,7 @@ class RdfTypeFactory
     public function getTypeByObject($object)
     {
         return $this->getTypeByName(
-            $this->driver->objectToName($object, $this->mapper)
+            $this->mapper->objectToName($object)
         );
     }
 

--- a/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
@@ -5,7 +5,6 @@
  * @license Dual licensed under the MIT (MIT-LICENSE.txt) and LGPL (LGPL-LICENSE.txt) licenses.
  * @package Midgard.CreatePHP
  */
-
 namespace Midgard\CreatePHP;
 
 use Midgard\CreatePHP\Type\TypeInterface;

--- a/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
@@ -8,6 +8,8 @@
 
 namespace Midgard\CreatePHP;
 
+use Midgard\CreatePHP\Type\TypeInterface;
+
 /**
  * Map from CreatePHP to your domain objects
  *
@@ -29,9 +31,9 @@ interface RdfChainableMapperInterface extends RdfMapperInterface
     /**
      * Get if this mapper can create this type.
      *
-     * @param mixed $object
+     * @param TypeInterface $type
      *
      * @return boolean
      */
-    public function supportsCreate($object);
+    public function supportsCreate(TypeInterface $type);
 }

--- a/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
@@ -11,9 +11,9 @@ namespace Midgard\CreatePHP;
 use Midgard\CreatePHP\Type\TypeInterface;
 
 /**
- * Map from CreatePHP to your domain objects
+ * Mappers that implement this interface can be used the the chain mapper.
  *
- * You can have a mapper per type or a generic mapper that handles all types.
+ * Tests whether the mapper supports and object or can create an object of a type.
  *
  * @package Midgard.CreatePHP
  */

--- a/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfChainableMapperInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright CONTENT CONTROL GmbH, http://www.contentcontrol-berlin.de
+ * @author CONTENT CONTROL GmbH, http://www.contentcontrol-berlin.de
+ * @license Dual licensed under the MIT (MIT-LICENSE.txt) and LGPL (LGPL-LICENSE.txt) licenses.
+ * @package Midgard.CreatePHP
+ */
+
+namespace Midgard\CreatePHP;
+
+/**
+ * Map from CreatePHP to your domain objects
+ *
+ * You can have a mapper per type or a generic mapper that handles all types.
+ *
+ * @package Midgard.CreatePHP
+ */
+interface RdfChainableMapperInterface extends RdfMapperInterface
+{
+    /**
+     * Get if the object can be handled by this mapper.
+     *
+     * @param mixed $object
+     *
+     * @return boolean
+     */
+    public function supports($object);
+
+    /**
+     * Get if this mapper can create this type.
+     *
+     * @param mixed $object
+     *
+     * @return boolean
+     */
+    public function supportsCreate($object);
+}

--- a/src/Midgard/CreatePHP/RdfMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfMapperInterface.php
@@ -63,6 +63,17 @@ interface RdfMapperInterface
     public function getChildren($object, CollectionInterface $collection);
 
     /**
+     * Ensure the parameter is transformed into the canonical name string for
+     * the passed parameter.
+     *
+     * @param string $name a name as passed to the RDF type factory
+     *
+     * @return string the canonical name
+     * @deprecated Deprecated in 1.1 use objectToName instead.
+     */
+    public function canonicalName($className);
+
+    /**
      * Instantiate a new object for the specified RDFa type
      *
      * Used as empty template for collections, and to instantiate an empty

--- a/src/Midgard/CreatePHP/RdfMapperInterface.php
+++ b/src/Midgard/CreatePHP/RdfMapperInterface.php
@@ -63,23 +63,6 @@ interface RdfMapperInterface
     public function getChildren($object, CollectionInterface $collection);
 
     /**
-     * Ensure the parameter is transformed into the canonical name string for
-     * the passed parameter.
-     *
-     * This may include fixing
-     * uppercase, normalizing doctrine proxy class name to original class
-     * name and so on.
-     *
-     * If you do not know what to do, just check if its an object and if so
-     * return get_class, otherwise return the string as passed in.
-     *
-     * @param string $name a name as passed to the RDF type factory
-     *
-     * @return string the canonical name
-     */
-    public function canonicalName($className);
-
-    /**
      * Instantiate a new object for the specified RDFa type
      *
      * Used as empty template for collections, and to instantiate an empty
@@ -110,6 +93,25 @@ interface RdfMapperInterface
      * @return mixed The storage object or false if nothing is found
      */
     public function getBySubject($subject);
+
+    /**
+     * Get the name for the object.
+     *
+     * Ensure the name is transformed into the canonical name string for
+     * the passed object.
+     *
+     * This may include fixing
+     * uppercase, normalizing doctrine proxy class name to original class
+     * name and so on.
+     *
+     * If you do not know what to do, just check if its an object and if so
+     * return get_class, otherwise return the string as passed in.
+     *
+     * @param object $object
+     *
+     * @return string the canonical name of this object
+     */
+    public function objectToName($object);
 
     /**
      * Create json-ld subject (RDFa about) for this object (could be simply the

--- a/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
+++ b/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
@@ -101,8 +101,8 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($collection->getChildren()))
         ;
         $this->mapper->expects($this->any())
-            ->method('canonicalName')
-            ->will($this->returnCallback(array($this, 'canonicalNameCallback')))
+            ->method('objectToName')
+            ->will($this->returnCallback(array($this, 'objectToNameCallback')))
         ;
 
         $xml = $this->renderXml('collection.twig');
@@ -147,9 +147,8 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sioc:content', $xml->ul->li[1]->div[1]['property']);
     }
 
-    public function canonicalNameCallback($className) {
-
-        if ($className === 'Test\Midgard\CreatePHP\Collection') {
+    public function objectToNameCallback($object) {
+        if (get_class($object) === 'Test\Midgard\CreatePHP\Collection') {
             return 'Test\Midgard\CreatePHP\Collection';
         } else {
             return 'Test\Midgard\CreatePHP\Model';
@@ -196,8 +195,8 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('/the/subject'))
         ;
         $this->mapper->expects($this->any())
-            ->method('canonicalName')
-            ->with(get_class($model))
+            ->method('objectToName')
+            ->with($model)
             ->will($this->returnValue(get_class($model)))
         ;
     }

--- a/tests/__files/MockMapper.php
+++ b/tests/__files/MockMapper.php
@@ -55,6 +55,11 @@ class MockMapper implements RdfMapperInterface
 
     }
 
+    public function canonicalName($className)
+    {
+        return $className;
+    }
+
     public function objectToName($object)
     {
         return get_class($object);

--- a/tests/__files/MockMapper.php
+++ b/tests/__files/MockMapper.php
@@ -55,9 +55,9 @@ class MockMapper implements RdfMapperInterface
 
     }
 
-    public function canonicalName($className)
+    public function objectToName($object)
     {
-        return $className;
+        return get_class($object);
     }
 
     public function getBySubject($identifier)


### PR DESCRIPTION
I've written a potential implementation of a chain mapper (such as discussed in #58).

I've been using this to successfully use both PHPCR and ORM for a few months now, but only for editing existing content. I've only recently started looking into creating content with the createjs. 

I made a breaking change to the RdfMapperInterface to handle resolving object names. Since I don't have a very in-depth knowledge of the workings of createphp I'm not sure how much this will affect users of the library. (Or, for that matter, most of my changes. I've only spent a cursory amount of time looking at create)