### PR TITLE
prepareObject() implementation for DoctrineOrmMapper

### DIFF
--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -46,4 +46,3 @@ names. There are several drivers available:
   quick hack, but does not produce meaningful RDF.
 
 Look at the driver phpdoc for the exact syntax to use for configuration.
-


### PR DESCRIPTION
Continuation from #73 

I squashed the commits, and then had a good look again. For the ORM, having a parent relation is not necessary to be able to store a document. I thus changed the implementation to make setting the parent optional. @bitladen-nw can you please have a look at this and check if it works for you too?

Was the problem you encountered that the base prepareObject implementation was confused by being passed a $parent? Do you actually need a parent to be set in your entities?