### PR TITLE
Update to latest PHPUnit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "homepage": "http://www.contentcontrol-berlin.de/"
         }
     ],
+    "require": {
+        "php": "^5.6 | ^7.0"
+    },
     "require-dev": {
         "twig/twig": "~1.8",
         "doctrine/common": "~2.3.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }

--- a/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
+++ b/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
@@ -34,7 +34,7 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Twig is not installed.');
         }
 
-        $this->mapper = $this->getMock('Midgard\CreatePHP\RdfMapperInterface');
+        $this->mapper = $this->createMock('Midgard\CreatePHP\RdfMapperInterface');
 
         $xmlDriver = new RdfDriverXml(array(__DIR__.'/../../Metadata/rdf-twig'));
         $this->factory = new RdfTypeFactory($this->mapper, $xmlDriver);

--- a/tests/Test/Midgard/CreatePHP/Mapper/DoctrineOrmMapperTest.php
+++ b/tests/Test/Midgard/CreatePHP/Mapper/DoctrineOrmMapperTest.php
@@ -31,21 +31,21 @@ class DoctrineOrmMapperTest extends \PHPUnit_Framework_TestCase
     {
         $entity = new MockOrmEntity();
 
-        $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
         $repository
             ->expects($this->once())
             ->method('find')
             ->with($ids)
             ->will($this->returnValue($entity))
         ;
-        $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $om = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
         $om
             ->expects($this->once())
             ->method('getRepository')
             ->with(get_class($entity))
             ->will($this->returnValue($repository))
         ;
-        $meta = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $meta = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
         $meta
             ->expects($this->once())
             ->method('getIdentifierValues')
@@ -58,7 +58,7 @@ class DoctrineOrmMapperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($meta))
         ;
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry
             ->expects($this->once())
             ->method('getManager')
@@ -68,7 +68,7 @@ class DoctrineOrmMapperTest extends \PHPUnit_Framework_TestCase
         $mapper = new DoctrineOrmMapper(array(), $registry);
         $subject = $mapper->createSubject($entity);
         $this->assertSame($entity, $mapper->getBySubject($subject));
-        
+
         $className = str_replace('\\', '-', get_class($entity));
         $this->assertContains($className, $subject);
     }

--- a/tests/Test/Midgard/CreatePHP/Mapper/DoctrinePhpcrMapperTest.php
+++ b/tests/Test/Midgard/CreatePHP/Mapper/DoctrinePhpcrMapperTest.php
@@ -14,9 +14,9 @@ class DoctrinePhpcrMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $om = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry
           ->expects($this->once())
           ->method('getManager')

--- a/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverArrayTest.php
+++ b/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverArrayTest.php
@@ -62,7 +62,7 @@ class RdfDriverArrayTest extends RdfDriverBase
 
     public function testLoadType()
     {
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
         $typeFactory = $this->getMockBuilder('Midgard\\CreatePHP\\Metadata\\RdfTypeFactory')->disableOriginalConstructor()->getMock();
         $itemType = new Controller($mapper);
         $itemType->addRev('my:customRev');
@@ -82,7 +82,7 @@ class RdfDriverArrayTest extends RdfDriverBase
      */
     public function testLoadTypeForClassNodefinition()
     {
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
         $typeFactory = $this->getMockBuilder('Midgard\\CreatePHP\\Metadata\\RdfTypeFactory')->disableOriginalConstructor()->getMock();
         $type = $this->driver->loadType('Midgard\\CreatePHP\\Not\\Existing\\Class', $mapper, $typeFactory);
     }
@@ -109,7 +109,7 @@ class RdfDriverArrayTest extends RdfDriverBase
      */
     public function testGetRevOptions()
     {
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
         $typeFactory = $this->getMockBuilder('Midgard\\CreatePHP\\Metadata\\RdfTypeFactory')->disableOriginalConstructor()->getMock();
         $type = $this->driver->loadType('Test\\Midgard\\CreatePHP\\Model', $mapper, $typeFactory);
 

--- a/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverXmlTest.php
+++ b/tests/Test/Midgard/CreatePHP/Metadata/RdfDriverXmlTest.php
@@ -20,7 +20,7 @@ class RdfDriverXmlTest extends RdfDriverBase
 
     public function testLoadTypeForClass()
     {
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
         $typeFactory = $this->getMockBuilder('Midgard\\CreatePHP\\Metadata\\RdfTypeFactory')->disableOriginalConstructor()->getMock();
         $itemType = new Controller($mapper);
         $itemType->addRev('my:customRev');
@@ -40,7 +40,7 @@ class RdfDriverXmlTest extends RdfDriverBase
      */
     public function testLoadTypeForClassNodefinition()
     {
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
         $typeFactory = $this->getMockBuilder('Midgard\\CreatePHP\\Metadata\\RdfTypeFactory')->disableOriginalConstructor()->getMock();
         $this->driver->loadType('Midgard\\CreatePHP\\Not\\Existing\\Class', $mapper, $typeFactory);
     }
@@ -68,7 +68,7 @@ class RdfDriverXmlTest extends RdfDriverBase
      */
     public function testGetRevOptions()
     {
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
         $typeFactory = $this->getMockBuilder('Midgard\\CreatePHP\\Metadata\\RdfTypeFactory')->disableOriginalConstructor()->getMock();
         $type = $this->driver->loadType('Test\\Midgard\\CreatePHP\\Model', $mapper, $typeFactory);
 

--- a/tests/Test/Midgard/CreatePHP/RestServiceTest.php
+++ b/tests/Test/Midgard/CreatePHP/RestServiceTest.php
@@ -39,12 +39,12 @@ class RestServiceTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
-        $this->type = $this->getMock('Midgard\\CreatePHP\\Type\\TypeInterface');
-        $this->child_type = $this->getMock('Midgard\\CreatePHP\\Type\\TypeInterface');
-        $this->entity = $this->getMock('Midgard\\CreatePHP\\Entity\\EntityInterface');
-        $this->property = $this->getMock('Midgard\\CreatePHP\\Entity\\PropertyInterface');
-        $this->collection = $this->getMock('Midgard\\CreatePHP\\Entity\\CollectionInterface');
+        $this->mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $this->type = $this->createMock('Midgard\\CreatePHP\\Type\\TypeInterface');
+        $this->child_type = $this->createMock('Midgard\\CreatePHP\\Type\\TypeInterface');
+        $this->entity = $this->createMock('Midgard\\CreatePHP\\Entity\\EntityInterface');
+        $this->property = $this->createMock('Midgard\\CreatePHP\\Entity\\PropertyInterface');
+        $this->collection = $this->createMock('Midgard\\CreatePHP\\Entity\\CollectionInterface');
 
         $this->mapper->expects($this->once())
             ->method('store')

--- a/tests/Test/Midgard/CreatePHP/RestServiceWorkflowTest.php
+++ b/tests/Test/Midgard/CreatePHP/RestServiceWorkflowTest.php
@@ -10,7 +10,7 @@ class RestServiceWorkflowTest extends \PHPUnit_Framework_TestCase
     public function test_get_registerWorkflow()
     {
         $workflow = new MockWorkflow;
-        $mapper = $this->getMock('Midgard\\CreatePHP\\RdfMapperInterface');
+        $mapper = $this->createMock('Midgard\\CreatePHP\\RdfMapperInterface');
 
         $restHandler = new RestService($mapper);
 


### PR DESCRIPTION
Since PHPUnit 5.4.0, getMock() is deprecated in favor of createMock().