### PR TITLE
Twig 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.0"
     },
     "require-dev": {
-        "twig/twig": "^2.1",
+        "twig/twig": "^1.31 | ^2.1",
         "doctrine/common": "~2.3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^5.6 | ^7.0"
     },
     "require-dev": {
         "twig/twig": "^1.31 | ^2.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^5.6 | ^7.0"
     },
     "require-dev": {
-        "twig/twig": "~1.8",
+        "twig/twig": "^2.1",
         "doctrine/common": "~2.3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 | ^7.0"
+        "php": "^7.0"
     },
     "require-dev": {
         "twig/twig": "^2.1",

--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpExtension.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpExtension.php
@@ -10,7 +10,7 @@ namespace Midgard\CreatePHP\Extension\Twig;
 
 use Twig_Extension;
 use Twig_Environment;
-use Twig_Function;
+use Twig_SimpleFunction;
 use Twig_Error_Runtime;
 
 use Midgard\CreatePHP\NodeInterface;
@@ -58,8 +58,8 @@ class CreatephpExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            new Twig_Function('createphp_attributes', [$this, 'renderAttributes'], array('is_safe' => array('html'))),
-            new Twig_Function('createphp_content', [$this, 'renderContent'], array('is_safe' => array('html'))),
+            new Twig_SimpleFunction('createphp_attributes', [$this, 'renderAttributes'], array('is_safe' => array('html'))),
+            new Twig_SimpleFunction('createphp_content', [$this, 'renderContent'], array('is_safe' => array('html'))),
 
         );
     }

--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpExtension.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpExtension.php
@@ -10,7 +10,7 @@ namespace Midgard\CreatePHP\Extension\Twig;
 
 use Twig_Extension;
 use Twig_Environment;
-use Twig_Function_Method;
+use Twig_Function;
 use Twig_Error_Runtime;
 
 use Midgard\CreatePHP\NodeInterface;
@@ -58,8 +58,8 @@ class CreatephpExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            'createphp_attributes'  => new Twig_Function_Method($this, 'renderAttributes', array('is_safe' => array('html'))),
-            'createphp_content'     => new Twig_Function_Method($this, 'renderContent', array('is_safe' => array('html'))),
+            new Twig_Function('createphp_attributes', [$this, 'renderAttributes'], array('is_safe' => array('html'))),
+            new Twig_Function('createphp_content', [$this, 'renderContent'], array('is_safe' => array('html'))),
 
         );
     }

--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpExtension.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpExtension.php
@@ -120,14 +120,4 @@ class CreatephpExtension extends Twig_Extension
         return $type->createWithObject($model);
     }
 
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'createphp';
-    }
-
 }

--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpNode.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpNode.php
@@ -8,7 +8,6 @@
 
 namespace Midgard\CreatePHP\Extension\Twig;
 
-use Twig_NodeInterface;
 use Twig_Node;
 use Twig_Compiler;
 
@@ -26,16 +25,16 @@ class CreatephpNode extends Twig_Node
      *
      *  * varname: The name of the rdfa entity to expose to the body node
      *
-     * @param Twig_NodeInterface $body     The body of the createphp token
-     * @param Twig_NodeInterface $object   The object to convert to rdf
+     * @param Twig_Node $body     The body of the createphp token
+     * @param Twig_Node $object   The object to convert to rdf
      * @param string|null        $varname  The name for the rdfa entity to expose or null if no explicit name
      * @param boolean            $autotag  Automatically render start and end part of the node?
      * @param integer            $lineno   The line number
      * @param string             $tag      The tag name
      */
     public function __construct(
-        Twig_NodeInterface $body,
-        Twig_NodeInterface $object,
+        Twig_Node $body,
+        Twig_Node $object,
         $varname,
         $autotag,
         $lineno = 0,
@@ -126,11 +125,11 @@ class CreatephpNode extends Twig_Node
      *
      * For example container.method.content will make the name "content"
      *
-     * @param Twig_NodeInterface $node
+     * @param Twig_Node $node
      *
      * @return string|null get the variable name
      */
-    protected function findVariableName(Twig_NodeInterface $node)
+    protected function findVariableName(Twig_Node $node)
     {
         $name = null;
         if ($node instanceof \Twig_Node_Expression_Name) {

--- a/src/Midgard/CreatePHP/Extension/Twig/CreatephpNode.php
+++ b/src/Midgard/CreatePHP/Extension/Twig/CreatephpNode.php
@@ -111,7 +111,7 @@ class CreatephpNode extends Twig_Node
     protected function compileTypeLoad(Twig_Compiler $compiler, $modelname)
     {
         $compiler
-            ->write('$this->env->getExtension(\'createphp\')->createEntity(')
+            ->write('$this->env->getExtension(\'Midgard\\CreatePHP\\Extension\\Twig\\CreatephpExtension\')->createEntity(')
         ;
         $compiler->subcompile($this->getAttribute('object'));
         $compiler

--- a/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
+++ b/tests/Test/Midgard/CreatePHP/Extension/Twig/CreatephpExtensionTest.php
@@ -39,8 +39,8 @@ class CreatephpExtensionTest extends \PHPUnit_Framework_TestCase
         $xmlDriver = new RdfDriverXml(array(__DIR__.'/../../Metadata/rdf-twig'));
         $this->factory = new RdfTypeFactory($this->mapper, $xmlDriver);
 
-        $this->twig = new \Twig_Environment();
-        $this->twig->setLoader(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        $loader = new \Twig_Loader_Filesystem(__DIR__.'/templates');
+        $this->twig = new \Twig_Environment($loader);
         $this->twig->addExtension(new CreatephpExtension($this->factory));
     }
 


### PR DESCRIPTION
This is a simple Twig 2 support.
Maybe some refactoring is necessary to follow Twig 2 conventions.

Twig 2 require PHP 7, but supporting it will be necessary to allow symfony-cmf/create-bundle to support Symfony 3.